### PR TITLE
Add access token caching to the provider

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -145,6 +145,9 @@ func main() {
 	metrics.Registry.MustRegister(metricRecorder)
 	metrics.Registry.MustRegister(stateMetrics)
 
+	setupFn, err := clients.TerraformSetupBuilder(log)
+	kingpin.FatalIfError(err, "Cannot build Terraform setup function")
+
 	clusterOpts := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,
@@ -162,7 +165,7 @@ func main() {
 		// use the following WorkspaceStoreOption to enable the shared gRPC mode
 		// terraform.WithProviderRunner(terraform.NewSharedProvider(log, os.Getenv("TERRAFORM_NATIVE_PROVIDER_PATH"), terraform.WithNativeProviderArgs("-debuggable")))
 		WorkspaceStore:        terraform.NewWorkspaceStore(log),
-		SetupFn:               clients.TerraformSetupBuilder(),
+		SetupFn:               setupFn,
 		OperationTrackerStore: tjcontroller.NewOperationStore(log),
 		StartWebhooks:         *certsDir != "",
 	}
@@ -184,7 +187,7 @@ func main() {
 		// use the following WorkspaceStoreOption to enable the shared gRPC mode
 		// terraform.WithProviderRunner(terraform.NewSharedProvider(log, os.Getenv("TERRAFORM_NATIVE_PROVIDER_PATH"), terraform.WithNativeProviderArgs("-debuggable")))
 		WorkspaceStore:        terraform.NewWorkspaceStore(log),
-		SetupFn:               clients.TerraformSetupBuilder(),
+		SetupFn:               setupFn,
 		OperationTrackerStore: tjcontroller.NewOperationStore(log),
 		StartWebhooks:         *certsDir != "",
 	}

--- a/config/provider-metadata.yaml
+++ b/config/provider-metadata.yaml
@@ -119,7 +119,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${var.cloud_provider}",
                   "cluster_configuration": {
                     "custom_properties_json": "${jsonencode({\n      \"schema_registry_enable_authorization\" = true\n    })}"
@@ -140,6 +140,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: var.cloud_provider
                 name: var.cluster_name
                 network_id: redpanda_network.test.id
@@ -212,6 +213,21 @@ resources:
                 redpanda_resource_group.test: |-
                     {
                       "name": "${var.resource_group_name}"
+                    }
+                redpanda_role.developer: |-
+                    {
+                      "allow_deletion": "${var.role_allow_deletion}",
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "name": "${var.role_name}"
+                    }
+                redpanda_role_assignment.developer_assignment: |-
+                    {
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "depends_on": [
+                        "${redpanda_user.test}"
+                      ],
+                      "principal": "${redpanda_user.test.name}",
+                      "role_name": "${redpanda_role.developer.name}"
                     }
                 redpanda_schema.product_schema: |-
                     {
@@ -422,7 +438,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${var.cloud_provider}",
                   "cluster_configuration": {
                     "custom_properties_json": "${jsonencode({\n      \"schema_registry_enable_authorization\" = true\n    })}"
@@ -440,6 +456,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: var.cloud_provider
                 name: var.cluster_name
                 network_id: redpanda_network.test.id
@@ -512,6 +529,21 @@ resources:
                 redpanda_resource_group.test: |-
                     {
                       "name": "${var.resource_group_name}"
+                    }
+                redpanda_role.developer: |-
+                    {
+                      "allow_deletion": "${var.role_allow_deletion}",
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "name": "${var.role_name}"
+                    }
+                redpanda_role_assignment.developer_assignment: |-
+                    {
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "depends_on": [
+                        "${redpanda_user.test}"
+                      ],
+                      "principal": "${redpanda_user.test.name}",
+                      "role_name": "${redpanda_role.developer.name}"
                     }
                 redpanda_schema.product_schema: |-
                     {
@@ -739,7 +771,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${var.cloud_provider}",
                   "cluster_configuration": {
                     "custom_properties_json": "${jsonencode({\n      \"schema_registry_enable_authorization\" = true\n    })}"
@@ -760,6 +792,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: var.cloud_provider
                 name: var.cluster_name
                 network_id: redpanda_network.test.id
@@ -808,6 +841,21 @@ resources:
                 redpanda_resource_group.test: |-
                     {
                       "name": "${var.resource_group_name}"
+                    }
+                redpanda_role.developer: |-
+                    {
+                      "allow_deletion": "${var.role_allow_deletion}",
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "name": "${var.role_name}"
+                    }
+                redpanda_role_assignment.developer_assignment: |-
+                    {
+                      "cluster_api_url": "${redpanda_cluster.test.cluster_api_url}",
+                      "depends_on": [
+                        "${redpanda_user.test}"
+                      ],
+                      "principal": "${redpanda_user.test.name}",
+                      "role_name": "${redpanda_role.developer.name}"
                     }
                 redpanda_schema.product_schema: |-
                     {
@@ -1026,7 +1074,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${redpanda_network.test.cloud_provider}",
                   "cluster_type": "${redpanda_network.test.cluster_type}",
                   "connection_type": "public",
@@ -1044,6 +1092,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: redpanda_network.test.cloud_provider
                 cluster_type: redpanda_network.test.cluster_type
                 name: var.cluster_name
@@ -1097,7 +1146,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${redpanda_network.test.cloud_provider}",
                   "cluster_type": "${redpanda_network.test.cluster_type}",
                   "connection_type": "public",
@@ -1109,6 +1158,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: redpanda_network.test.cloud_provider
                 cluster_type: redpanda_network.test.cluster_type
                 name: var.cluster_name
@@ -1162,7 +1212,7 @@ resources:
             - name: test
               manifest: |-
                 {
-                  "allow_deletion": true,
+                  "allow_deletion": "${var.cluster_allow_deletion}",
                   "cloud_provider": "${redpanda_network.test.cloud_provider}",
                   "cluster_type": "${redpanda_network.test.cluster_type}",
                   "connection_type": "public",
@@ -1177,6 +1227,7 @@ resources:
                   "zones": "${var.zones}"
                 }
               references:
+                allow_deletion: var.cluster_allow_deletion
                 cloud_provider: redpanda_network.test.cloud_provider
                 cluster_type: redpanda_network.test.cluster_type
                 name: var.cluster_name
@@ -1647,6 +1698,90 @@ resources:
             name: (String) Name of the resource group. Changing the name of a resource group will result in a new resource group being created and the old one being destroyed
         importStatements:
             - terraform import redpanda_resource_group.example resourcegroupId
+    redpanda_role:
+        subCategory: ""
+        description: Role is a role that can be created in Redpanda for RBAC management
+        name: redpanda_role
+        title: redpanda_role Resource - terraform-provider-redpanda
+        examples:
+            - name: example
+              manifest: |-
+                {
+                  "allow_deletion": true,
+                  "cluster_api_url": "${redpanda_cluster.example.cluster_api_url}",
+                  "name": "developer"
+                }
+              references:
+                cluster_api_url: redpanda_cluster.example.cluster_api_url
+              dependencies:
+                redpanda_cluster.example: |-
+                    {
+                      "cloud_provider": "aws",
+                      "cluster_type": "dedicated",
+                      "connection_type": "public",
+                      "name": "example-cluster",
+                      "network_id": "${redpanda_network.example.id}",
+                      "region": "us-west-2",
+                      "resource_group_id": "${redpanda_resource_group.example.id}",
+                      "throughput_tier": "tier-1-aws",
+                      "zones": [
+                        "us-west-2a",
+                        "us-west-2b",
+                        "us-west-2c"
+                      ]
+                    }
+                redpanda_network.example: |-
+                    {
+                      "cidr_block": "10.0.0.0/20",
+                      "cloud_provider": "aws",
+                      "cluster_type": "dedicated",
+                      "name": "example-network",
+                      "region": "us-west-2",
+                      "resource_group_id": "${redpanda_resource_group.example.id}"
+                    }
+                redpanda_resource_group.example: |-
+                    {
+                      "name": "example-resource-group"
+                    }
+                redpanda_role_assignment.example: |-
+                    {
+                      "cluster_api_url": "${redpanda_cluster.example.cluster_api_url}",
+                      "principal": "${redpanda_user.example.name}",
+                      "role_name": "${redpanda_role.example.name}"
+                    }
+                redpanda_user.example: |-
+                    {
+                      "allow_deletion": true,
+                      "cluster_api_url": "${redpanda_cluster.example.cluster_api_url}",
+                      "mechanism": "scram-sha-256",
+                      "name": "example-user",
+                      "password": "secure-password-123"
+                    }
+            - name: developer
+              manifest: |-
+                {
+                  "allow_deletion": true,
+                  "cluster_api_url": "${var.cluster_api_url}",
+                  "name": "developer"
+                }
+              references:
+                cluster_api_url: var.cluster_api_url
+              dependencies:
+                redpanda_role_assignment.dev_assignment: |-
+                    {
+                      "cluster_api_url": "${var.cluster_api_url}",
+                      "principal": "john.doe",
+                      "role_name": "${redpanda_role.developer.name}"
+                    }
+        argumentDocs:
+            DataEngineers: ', ReadOnlyAnalysts)'
+            TopicReaders: vs SuperUsers)
+            allow_deletion: (Boolean) Allows deletion of the role. If false, the role cannot be deleted and the resource will be removed from the state on destruction. Defaults to false.
+            cluster_api_url: (String) The cluster API URL. Changing this will prevent deletion of the resource on the existing cluster. It is generally a better idea to delete an existing resource and create a new one than to change this value unless you are planning to do state imports
+            id: (String) The ID of this resource.
+            name: (String) Name of the role, must be unique
+        importStatements:
+            - terraform import redpanda_role.example roleName,clusterId
     redpanda_role_assignment:
         subCategory: ""
         description: A role assignment is used for attaching one user to a role.
@@ -1702,12 +1837,12 @@ resources:
                       "password": "secure-password-123"
                     }
         argumentDocs:
-            '"john.doe"': '). The User: prefix is not needed and will be automatically stripped if provided.'
+            '"john.doe"': '). While Redpanda''s native format is User:username, this resource automatically handles the User: prefix for you. The prefix will be automatically stripped if provided.'
             cluster_api_url: (String) The cluster API URL. Changing this will prevent deletion of the resource on the existing cluster
             id: '(String) The ID of this resource. Format: {role_name}:{principal}'
             principal: (String) The principal to assign the role to. Specify just the username (e.g., "john.doe")
+            redpanda_role: resource, or import existing roles created via rpk or Redpanda Console.
             role_name: (String) The name of the role to assign
-            rpk security role create: or through the Redpanda Console.
         importStatements:
             - terraform import redpanda_role_assignment.test "test-role:test-user"
     redpanda_schema:
@@ -2078,9 +2213,19 @@ resources:
         argumentDocs:
             allow_deletion: (Boolean) Allows deletion of the user. If false, the user cannot be deleted and the resource will be removed from the state on destruction. Defaults to false.
             cluster_api_url: (String) The cluster API URL. Changing this will prevent deletion of the resource on the existing cluster. It is generally a better idea to delete an existing resource and create a new one than to change this value unless you are planning to do state imports
+            clusterId: is the ID of the cluster in Redpanda Cloud
             id: (String) The ID of this resource.
             mechanism: (String) Which authentication method to use, see https://docs.redpanda.com/current/manage/security/authentication/ for more information
             name: (String) Name of the user, must be unique
             password: (String, Sensitive) Password of the user
+            userName: is the name of the user
         importStatements:
-            - terraform import redpanda_user.example userName,clusterId
+            - |-
+              # Basic import with just user name and cluster ID
+              terraform import redpanda_user.example userName,clusterId
+
+              # Extended import with password
+              terraform import redpanda_user.example userName,clusterId,password
+
+              # Extended import with password and mechanism
+              terraform import redpanda_user.example userName,clusterId,password,mechanism

--- a/config/provider.go
+++ b/config/provider.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	// Note(turkenh): we are importing this to embed provider schema document
+	"context"
 	_ "embed"
 
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
@@ -26,7 +27,7 @@ func GetProvider() *ujconfig.Provider {
 		ujconfig.WithRootGroup("redpanda.crossplane.io"),
 		ujconfig.WithIncludeList(nil),
 		ujconfig.WithTerraformPluginFrameworkIncludeList(ExternalNameConfigured()),
-		ujconfig.WithTerraformPluginFrameworkProvider(redpanda.New(nil, "prod", "v1.3.5")()),
+		ujconfig.WithTerraformPluginFrameworkProvider(redpanda.New(context.Background(), "prod", "v1.3.5")()),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithDefaultResourceOptions(
@@ -49,7 +50,7 @@ func GetProviderNamespaced() *ujconfig.Provider {
 		ujconfig.WithRootGroup("redpanda.m.crossplane.io"),
 		ujconfig.WithIncludeList(nil),
 		ujconfig.WithTerraformPluginFrameworkIncludeList(ExternalNameConfigured()),
-		ujconfig.WithTerraformPluginFrameworkProvider(redpanda.New(nil, "prod", "v1.3.5")()),
+		ujconfig.WithTerraformPluginFrameworkProvider(redpanda.New(context.Background(), "prod", "v1.3.5")()),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithDefaultResourceOptions(

--- a/internal/clients/redpanda.go
+++ b/internal/clients/redpanda.go
@@ -1,12 +1,19 @@
+// Package clients provides Terraform setup functions for the Redpanda provider.
 package clients
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"strings"
+	"sync"
+	"time"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/pkg/errors"
 	"github.com/redpanda-data/terraform-provider-redpanda/redpanda"
+	"github.com/redpanda-data/terraform-provider-redpanda/redpanda/cloud"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,6 +26,7 @@ import (
 const (
 	clientID     = "client_id"
 	clientSecret = "client_secret"
+	accessToken  = "access_token"
 )
 
 const (
@@ -28,37 +36,123 @@ const (
 	errTrackUsage           = "cannot track ProviderConfig usage"
 	errExtractCredentials   = "cannot extract credentials"
 	errUnmarshalCredentials = "cannot unmarshal redpanda credentials as JSON"
+	errMissingCredentials   = "credentials must contain client_id and client_secret"
 )
 
-// TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
-// returns Terraform provider setup configuration
-func TerraformSetupBuilder() terraform.SetupFn {
-	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
+type tokenFetcher func(ctx context.Context, clientID, clientSecret string) (string, error)
+
+// tokenCache caches access tokens by clientID. get returns an error if the
+// cached token is missing or within a minute of expiry, so callers refetch
+// before the token can fail mid-request.
+type tokenCache struct {
+	mu     sync.RWMutex
+	tokens map[string]string
+}
+
+func (c *tokenCache) get(id string) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	token, ok := c.tokens[id]
+	if !ok {
+		return "", errors.New("no cached token")
+	}
+	exp, err := parseTokenExpiry(token)
+	if err != nil {
+		return "", err
+	}
+	if time.Until(exp) <= time.Minute {
+		return "", errors.New("token within 1m of expiry")
+	}
+
+	return token, nil
+}
+
+func (c *tokenCache) set(id, token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokens[id] = token
+}
+
+func parseTokenExpiry(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, errors.New("not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "decode JWT payload")
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, errors.Wrap(err, "unmarshal JWT claims")
+	}
+	return time.Unix(claims.Exp, 0), nil
+}
+
+// credentialExtractor extracts the clientID and clientSecret for a managed resource.
+// It is injectable so that buildSetupFn can be tested without a real K8s cluster.
+type credentialExtractor func(ctx context.Context, c client.Client, mg resource.Managed) (id, secret string, err error)
+
+// TerraformSetupBuilder builds a terraform.SetupFn that caches access tokens to
+// avoid generating a new token on every reconcile loop.
+func TerraformSetupBuilder(log logging.Logger) (terraform.SetupFn, error) {
+	endpoint, err := cloud.EndpointForEnv("prod")
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot resolve prod endpoint")
+	}
+	cache := &tokenCache{tokens: make(map[string]string)}
+	fetch := func(ctx context.Context, id, secret string) (string, error) {
+		return cloud.RequestToken(ctx, endpoint, id, secret)
+	}
+	return buildSetupFn(log, cache, fetch, extractCredentials), nil
+}
+
+// extractCredentials reads the clientID and clientSecret from the ProviderConfig
+// referenced by the managed resource.
+func extractCredentials(ctx context.Context, c client.Client, mg resource.Managed) (string, string, error) {
+	pcSpec, err := resolveProviderConfig(ctx, c, mg)
+	if err != nil {
+		return "", "", errors.Wrap(err, "cannot resolve provider config")
+	}
+	data, err := resource.CommonCredentialExtractor(ctx, pcSpec.Credentials.Source, c, pcSpec.Credentials.CommonCredentialSelectors)
+	if err != nil {
+		return "", "", errors.Wrap(err, errExtractCredentials)
+	}
+	creds := map[string]string{}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return "", "", errors.Wrap(err, errUnmarshalCredentials)
+	}
+	if creds[clientID] == "" || creds[clientSecret] == "" {
+		return "", "", errors.New(errMissingCredentials)
+	}
+	return creds[clientID], creds[clientSecret], nil
+}
+
+// buildSetupFn constructs a terraform.SetupFn using injected dependencies for
+// the token cache, fetcher, and credential extractor.
+func buildSetupFn(log logging.Logger, cache *tokenCache, fetch tokenFetcher, extract credentialExtractor) terraform.SetupFn {
+	return func(ctx context.Context, c client.Client, mg resource.Managed) (terraform.Setup, error) {
 		ps := terraform.Setup{}
 
-		pcSpec, err := resolveProviderConfig(ctx, client, mg)
+		id, secret, err := extract(ctx, c, mg)
 		if err != nil {
-			return terraform.Setup{}, errors.Wrap(err, "cannot resolve provider config")
+			return ps, err
 		}
 
-		data, err := resource.CommonCredentialExtractor(ctx, pcSpec.Credentials.Source, client, pcSpec.Credentials.CommonCredentialSelectors)
+		token, err := cache.get(id)
 		if err != nil {
-			return ps, errors.Wrap(err, errExtractCredentials)
-		}
-		creds := map[string]string{}
-		if err := json.Unmarshal(data, &creds); err != nil {
-			return ps, errors.Wrap(err, errUnmarshalCredentials)
+			log.Debug("fetching new access token", "clientID", id, "reason", err.Error())
+			token, err = fetch(ctx, id, secret)
+			if err != nil {
+				return ps, errors.Wrap(err, "cannot fetch access token")
+			}
+			cache.set(id, token)
 		}
 
-		// Set credentials in Terraform provider configuration.
-		ps.Configuration = map[string]any{}
-		if v, ok := creds[clientID]; ok {
-			ps.Configuration[clientID] = v
-		}
-		if v, ok := creds[clientSecret]; ok {
-			ps.Configuration[clientSecret] = v
-		}
-		ps.FrameworkProvider = redpanda.New(nil, "prod", "v1.3.5")()
+		ps.Configuration = map[string]any{accessToken: token}
+		ps.FrameworkProvider = redpanda.New(ctx, "prod", "v1.3.5")()
 		return ps, nil
 	}
 }

--- a/internal/clients/redpanda_test.go
+++ b/internal/clients/redpanda_test.go
@@ -1,0 +1,132 @@
+package clients
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func jwt(t *testing.T, exp time.Time) string {
+	t.Helper()
+	payload := fmt.Sprintf(`{"exp":%d}`, exp.Unix())
+	return "h." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".s"
+}
+
+func TestParseTokenExpiry(t *testing.T) {
+	want := time.Unix(time.Now().Add(time.Hour).Unix(), 0)
+
+	cases := map[string]struct {
+		token   string
+		want    time.Time
+		wantErr bool
+	}{
+		"valid JWT": {
+			token: jwt(t, want),
+			want:  want,
+		},
+		"wrong segment count": {
+			token:   "h.p",
+			wantErr: true,
+		},
+		"invalid base64 payload": {
+			token:   "h.!!!.s",
+			wantErr: true,
+		},
+		"invalid JSON payload": {
+			token:   "h." + base64.RawURLEncoding.EncodeToString([]byte("not-json")) + ".s",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseTokenExpiry(tc.token)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (time=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func callSetupFn(t *testing.T, cache *tokenCache, fetch tokenFetcher, id, secret string) (map[string]any, error) {
+	t.Helper()
+	extract := func(_ context.Context, _ client.Client, _ resource.Managed) (string, string, error) {
+		return id, secret, nil
+	}
+	setup, err := buildSetupFn(logging.NewNopLogger(), cache, fetch, extract)(context.Background(), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return setup.Configuration, nil
+}
+
+func TestBuildSetupFn_CachesAndExposesToken(t *testing.T) {
+	calls := 0
+	token := jwt(t, time.Now().Add(24*time.Hour))
+	fetch := func(_ context.Context, _, _ string) (string, error) {
+		calls++
+		return token, nil
+	}
+	cache := &tokenCache{tokens: make(map[string]string)}
+
+	for i := 0; i < 2; i++ {
+		cfg, err := callSetupFn(t, cache, fetch, "id", "secret")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if cfg[accessToken] != token {
+			t.Errorf("call %d: wrong token", i)
+		}
+		if _, ok := cfg[clientID]; ok {
+			t.Errorf("call %d: client_id leaked", i)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fetch, got %d", calls)
+	}
+}
+
+func TestBuildSetupFn_RefetchesNearExpiryToken(t *testing.T) {
+	tokens := []string{
+		jwt(t, time.Now().Add(30*time.Second)),
+		jwt(t, time.Now().Add(24*time.Hour)),
+	}
+	calls := 0
+	fetch := func(_ context.Context, _, _ string) (string, error) {
+		tok := tokens[calls]
+		calls++
+		return tok, nil
+	}
+	cache := &tokenCache{tokens: make(map[string]string)}
+
+	// First call: empty cache, fetcher returns a near-expiry token; trusted and cached.
+	if _, err := callSetupFn(t, cache, fetch, "id", "secret"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call: cached token is within the expiry buffer, so cache.get errors and triggers a refetch.
+	if _, err := callSetupFn(t, cache, fetch, "id", "secret"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	// Third call: healthy cached token, no fetch.
+	if _, err := callSetupFn(t, cache, fetch, "id", "secret"); err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fetches (near-expiry + good), got %d", calls)
+	}
+}


### PR DESCRIPTION
### Description of your changes

Redpanda access tokens are good for ~24hr and requests to create new ones can be rate limited. This uses an in-process cache to store them between runs.

Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

note: I didn't see a `reviewable test` target in the makefile

### How has this code been tested

* Created a local setup via k3d
* Started the process and ensured that only one access token was granted
* Also added basic (unit) test coverage

[contribution process]: https://git.io/fj2m9
